### PR TITLE
FIX: Rerender of root layout on 404

### DIFF
--- a/src/layouts/RootLayout.tsx
+++ b/src/layouts/RootLayout.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 
-import { Outlet } from 'react-router';
+import { Outlet, useParams } from 'react-router';
 
 import { Grid2 as Grid, useMediaQuery } from '@mui/material';
 
@@ -38,6 +38,8 @@ export const RootLayout = ({
     const handleSidebarToggle = () => {
         setSidebarOpen((prev) => !prev);
     };
+    const params = useParams();
+    const is404 = '*' in params;
 
     return (
         <Grid height="100vh">
@@ -48,7 +50,7 @@ export const RootLayout = ({
                 />
             </Grid>
             <Grid container direction="row">
-                {!(hideSidebar && isDesktop) && (
+                {!((is404 || hideSidebar) && isDesktop) && (
                     <Grid sx={{ width: { md: SIDEBAR_WIDTH } }}>
                         <Sidebar
                             isSidebarOpen={isSidebarOpen}
@@ -69,7 +71,9 @@ export const RootLayout = ({
                         <main>
                             <Outlet />
                         </main>
-                        {!hideFooter && <Footer socialLinks={FOOTER_LINKS} />}
+                        {!(is404 || hideFooter) && (
+                            <Footer socialLinks={FOOTER_LINKS} />
+                        )}
                     </ErrorBoundary>
                 </Grid>
             </Grid>

--- a/src/router/routes.tsx
+++ b/src/router/routes.tsx
@@ -22,10 +22,6 @@ export const routes: RouteObject[] = [
                 element: <HomePage />,
             },
             {
-                path: '/auth',
-                element: 'dhb',
-            },
-            {
                 path: '*',
                 element: <ErrorScreen status={404} />,
             },

--- a/src/router/routes.tsx
+++ b/src/router/routes.tsx
@@ -21,13 +21,10 @@ export const routes: RouteObject[] = [
                 index: true,
                 element: <HomePage />,
             },
-        ],
-    },
-
-    {
-        path: '/',
-        element: <RootLayout hideSidebar={true} hideFooter={true} />,
-        children: [
+            {
+                path: '/auth',
+                element: 'dhb',
+            },
             {
                 path: '*',
                 element: <ErrorScreen status={404} />,


### PR DESCRIPTION
#### Description:

- Use params to target 404 path in root layout
- Updates to routes to prevent rerender of root layout

#### Development Checklist

- [x] Documentation added at appropriate places
- [x] UI & Responsiveness verified if needed
- [x] Tested Cross-browser / Cross-platform
- [x] Self review complete
- [x] Build script is running with no issues
- [x] Lint issues resolved
- [x] Files Formatted as per preferred formatter

#### Review Checklist

- [x] Checked edge cases
- [x] Reviewed code and documentation
- [x] Verified best practices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - 404 pages no longer display the sidebar or footer on desktop, providing a cleaner error view.

- Refactor
  - Simplified routing by consolidating routes under a single root path.
  - Moved 404 handling into the root route alongside the homepage for more consistent error behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->